### PR TITLE
Webhook Avatar URL Backport and Improve API for DiscordMessage

### DIFF
--- a/scripting/include/discord.inc
+++ b/scripting/include/discord.inc
@@ -345,6 +345,22 @@ methodmap DiscordMessage < Handle
   public native void GetAuthorName(char[] buffer, int maxlength);
 
   /**
+   * Gets the global display name of the message author
+   *
+   * @param buffer      Buffer to store the display name
+   * @param maxlength   Maximum length of the buffer
+   */
+  public native void GetAuthorDisplayName(char[] buffer, int maxlength);
+
+  /**
+   * Gets the nickname of the message author within the guild this message was sent in
+   *
+   * @param buffer      Buffer to store the author nickname
+   * @param maxlength   Maximum length of the buffer
+   */
+  public native void GetAuthorNickname(char[] buffer, int maxlength);
+
+  /**
    * Gets the discriminator of the message author
    *
    * @param buffer      Buffer to store the discriminator

--- a/scripting/include/discord.inc
+++ b/scripting/include/discord.inc
@@ -430,6 +430,21 @@ methodmap DiscordWebhook < Handle
    * @param name		New string to set the name to
    */
   public native void SetName(char[] name);
+
+  /**
+   * Gets the avatar_url of the webhook
+   *
+   * @param buffer      Buffer to store the url
+   * @param maxlength   Maximum length of the buffer
+   */
+  public native void GetAvatarUrl(char[] buffer, int maxlength);
+
+  /**
+   * Sets the avatar_url of the webhook
+   *
+   * @param name		New string to set the avatar_url to
+   */
+  public native void SetAvatarUrl(char[] avatarUrl);
 }
 
 /**

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -1017,6 +1017,30 @@ static cell_t webhook_SetName(IPluginContext* pContext, const cell_t* params)
 	return 1;
 }
 
+static cell_t webhook_GetAvatarUrl(IPluginContext* pContext, const cell_t* params)
+{
+	DiscordWebhook* webhook = GetWebhookPointer(pContext, params[1]);
+	if (!webhook) {
+		return 0;
+	}
+
+	pContext->StringToLocal(params[2], params[3], webhook->GetAvatarUrl());
+	return 1;
+}
+
+static cell_t webhook_SetAvatarUrl(IPluginContext* pContext, const cell_t* params)
+{
+	DiscordWebhook* webhook = GetWebhookPointer(pContext, params[1]);
+	if (!webhook) {
+		return 0;
+	}
+
+	char* avatar_url;
+	pContext->LocalToString(params[2], &avatar_url);
+	webhook->SetAvatarUrl(avatar_url);
+	return 1;
+}
+
 bool DiscordClient::RegisterSlashCommand(dpp::snowflake guild_id, const char* name, const char* description)
 {
 	if (!m_isRunning) {
@@ -1802,6 +1826,8 @@ const sp_nativeinfo_t discord_natives[] = {
 	{"DiscordWebhook.GetId",       webhook_GetId},
 	{"DiscordWebhook.GetName",       webhook_GetName},
 	{"DiscordWebhook.SetName",       webhook_SetName},
+	{"DiscordWebhook.GetAvatarUrl",       webhook_GetAvatarUrl},
+	{"DiscordWebhook.SetAvatarUrl",       webhook_SetAvatarUrl},
 
 	// Embed
 	{"DiscordEmbed.DiscordEmbed", embed_CreateEmbed},

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -902,6 +902,28 @@ static cell_t message_GetAuthorName(IPluginContext* pContext, const cell_t* para
 	return 1;
 }
 
+static cell_t message_GetAuthorDisplayName(IPluginContext* pContext, const cell_t* params)
+{
+	DiscordMessage* message = GetMessagePointer(pContext, params[1]);
+	if (!message) {
+		return 0;
+	}
+
+	pContext->StringToLocal(params[2], params[3], message->GetAuthorDisplayName());
+	return 1;
+}
+
+static cell_t message_GetAuthorNickname(IPluginContext* pContext, const cell_t* params)
+{
+	DiscordMessage* message = GetMessagePointer(pContext, params[1]);
+	if (!message) {
+		return 0;
+	}
+
+	pContext->StringToLocal(params[2], params[3], message->GetAuthorNickname());
+	return 1;
+}
+
 static cell_t message_GetAuthorDiscriminator(IPluginContext* pContext, const cell_t* params)
 {
 	DiscordMessage* message = GetMessagePointer(pContext, params[1]);
@@ -1815,6 +1837,8 @@ const sp_nativeinfo_t discord_natives[] = {
 	{"DiscordMessage.GetGuildId",    message_GetGuildId},
 	{"DiscordMessage.GetAuthorId",   message_GetAuthorId},
 	{"DiscordMessage.GetAuthorName", message_GetAuthorName},
+	{"DiscordMessage.GetAuthorDisplayName", message_GetAuthorDisplayName},
+	{"DiscordMessage.GetAuthorNickname", message_GetAuthorNickname},
 	{"DiscordMessage.GetAuthorDiscriminator", message_GetAuthorDiscriminator},
 	{"DiscordMessage.IsBot",         message_IsBot},
 

--- a/src/discord.h
+++ b/src/discord.h
@@ -73,6 +73,10 @@ public:
 	const char* GetName() const { return m_webhook.name.c_str(); }
 
 	void SetName(const char* value) { m_webhook.name = value; }
+
+	const char* GetAvatarUrl() const { return m_webhook.avatar_url.c_str(); }
+
+	void SetAvatarUrl(const char* value) { m_webhook.avatar_url = value; }
 };
 
 class DiscordClient

--- a/src/discord.h
+++ b/src/discord.h
@@ -44,6 +44,8 @@ public:
 	std::string GetGuildId() const { return std::to_string(m_message.guild_id); }
 	std::string GetAuthorId() const { return std::to_string(m_message.author.id); }
 	const char* GetAuthorName() const { return m_message.author.username.c_str(); }
+	const char* GetAuthorDisplayName() const { return m_message.author.global_name.c_str(); }
+	const char* GetAuthorNickname() const { return m_message.member.get_nickname().c_str(); }
 	const uint16_t GetAuthorDiscriminator() const { return m_message.author.discriminator; }
 	bool IsPinned() const { return m_message.pinned; }
 	bool IsTTS() const { return m_message.tts; }

--- a/third_party/DPP/include/dpp/webhook.h
+++ b/third_party/DPP/include/dpp/webhook.h
@@ -114,9 +114,18 @@ public:
 	/**
 	 * @brief The default avatar of the webhook.
 	 *
+	 * @note This value will not have any effect when `avatar_url` is set, they are mutually exclusive.
 	 * @note This may be empty.
 	 */
 	utility::iconhash avatar;
+
+	/**
+	 * @brief Avatar URL to use instead of the default if it is set.
+	 *
+	 * @note This will override `avatar` if it is set, they are mutually exclusive.
+	 * @note This may be empty.
+	 */
+	std::string avatar_url;
 
 	/**
 	 * @brief The secure token of the webhook (returned for Incoming Webhooks).

--- a/third_party/DPP/src/dpp/cluster/webhook.cpp
+++ b/third_party/DPP/src/dpp/cluster/webhook.cpp
@@ -72,12 +72,14 @@ void cluster::execute_webhook(const class webhook &wh, const struct message& m, 
 		{"thread_id", thread_id},
 	});
 	std::string body;
-	if (!thread_name.empty() || !wh.avatar.to_string().empty() || !wh.name.empty()) { // only use json::parse if thread_name is set
+	if (!thread_name.empty() || !wh.avatar.to_string().empty() || wh.avatar_url.empty() || !wh.name.empty()) { // only use json::parse if a value needs to be changed
 		json j = m.to_json(false);
 		if (!thread_name.empty()) {
 			j["thread_name"] = thread_name;
 		}
-		if (!wh.avatar.to_string().empty()) {
+		if (!wh.avatar_url.empty()) {
+			j["avatar_url"] = wh.avatar_url;
+		} else if (!wh.avatar.to_string().empty()) {
 			j["avatar_url"] = wh.avatar.to_string();
 		}
 		if (!wh.name.empty()) {


### PR DESCRIPTION
Backports and adds corresponding API for this pull request from upstream DPP: https://github.com/brainboxdotcc/DPP/pull/1419

Also allows you to get the global_name and nickname of the author of a message.